### PR TITLE
TEL-5887 fix missing package name from published zip

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,9 +1,9 @@
 [env]
 DOCKER_REPO="dockerhub.tax.service.gov.uk"
-LAMBDA_NAME="aws-lambda-telescope-msk"
 MDTP_ENVIRONMENT="internal-base"
+PACKAGE_NAME="aws-lambda-telescope-msk"
 PIP_INDEX_URL="https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple"
-S3_ADDRESS="s3://telemetry-{{env.MDTP_ENVIRONMENT}}-lambda-artifacts/build-{{env.LAMBDA_NAME}}"
+S3_ADDRESS="s3://telemetry-{{env.MDTP_ENVIRONMENT}}-lambda-artifacts/build-{{env.PACKAGE_NAME}}"
 TELEMETRY_INTERNAL_BASE_ACCOUNT_ID=634456480543
 UV_DEFAULT_INDEX="https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple"
 _.file = { path = ".env", redact = true }

--- a/.mise/tasks/publish
+++ b/.mise/tasks/publish
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #MISE depends=["package"]
-#MISE description="Take all the necessary steps to build and publish both lambda function's zip and checksum files"
+#MISE description="Publish both the zip and checksum files to S3"
 
 VERSION=$(cat .version)
 
-openssl dgst -sha256 -binary "${MISE_CONFIG_ROOT}/build/lambda.zip" | openssl enc -base64 > "${MISE_CONFIG_ROOT}/build/lambda.zip.base64sha256"
+openssl dgst -sha256 -binary "${MISE_CONFIG_ROOT}/build/package.zip" | openssl enc -base64 > "${MISE_CONFIG_ROOT}/build/package.zip.base64sha256"
 
-aws s3 cp "${MISE_CONFIG_ROOT}/build/lambda.zip" "${S3_ADDRESS}/${CANARY_NAME}.${VERSION}.zip" --acl=bucket-owner-full-control
-aws s3 cp "${MISE_CONFIG_ROOT}/build/lambda.zip.base64sha256" "${S3_ADDRESS}/${CANARY_NAME}.${VERSION}.zip.base64sha256" --content-type text/plain --acl=bucket-owner-full-control
+aws s3 cp "${MISE_CONFIG_ROOT}/build/package.zip" "${S3_ADDRESS}/${PACKAGE_NAME}.${VERSION}.zip" --acl=bucket-owner-full-control
+aws s3 cp "${MISE_CONFIG_ROOT}/build/package.zip.base64sha256" "${S3_ADDRESS}/${PACKAGE_NAME}.${VERSION}.zip.base64sha256" --content-type text/plain --acl=bucket-owner-full-control

--- a/bin/package.sh
+++ b/bin/package.sh
@@ -4,8 +4,8 @@ set -eu
 
 mkdir -p build
 cd "./${VENV_NAME}/lib/python${PYTHON_VERSION_LIB}/site-packages"
-zip -r "../../../../build/lambda.zip" .
+zip -r "../../../../build/package.zip" .
 cd -
 cd "./src"
-zip -r --grow "../build/lambda.zip" .
+zip -r --grow "../build/package.zip" .
 cd -


### PR DESCRIPTION
What did we do?
--

1. fix the missing package name from the s3 upload

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-5887

Evidence of work
--
```

upload: build/lambda.zip to s3://telemetry-internal-base-lambda-artifacts/build-aws-lambda-telescope-msk/.0.3.0.zip
--
[publish] Completed 45 Bytes/45 Bytes (522 Bytes/s) with 1 file(s) remaining
upload: build/lambda.zip.base64sha256 to s3://telemetry-internal-base-lambda-artifacts/build-aws-lambda-telescope-msk/.0.3.0.zip.base64sha256
[publish] Finished in 3.87s
Finished in 22.97s


```

Next Steps
--

1.

Risks
--

1.

Collaboration
--

Co-authored-by: @duddingl 
