### PR TITLE
TEL-5695 can we bump the major version without CodeBuild failure

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,6 +2,7 @@ version: 0.2
 env:
   shell: bash
   variables:
+    GIT_BRANCH: main # Ensure this is explicitly set so version incrementor can bump a major version
     MISE_DISABLE_TOOLS: uv # uv is already installed in the build container
 
 phases:


### PR DESCRIPTION
What did we do?
--

1. explicitly set the `GIT_BRANCH` env var for `.major-version` updates

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-5695

Evidence of work
--

Cause of failure
---
<img width="1735" height="343" alt="image" src="https://github.com/user-attachments/assets/50c3b5f9-4e3c-4457-866f-d287517aa3fe" />


Next Steps
--

1. Merge and check CodeBuild job

Risks
--

1.

Collaboration
--

Co-authored-by: @duddingl @nisartahir 
