### PR TITLE
TEL-5695 set uv and mise to the same explicit python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Team Telemetry", email = "telemetry@digital.hmrc.gov.uk" }]
 license = "Apache 2.0"
 maintainers = [{ name = "Team Telemetry", email = "telemetry@digital.hmrc.gov.uk" }]
 readme = "README.md"
-requires-python = ">=3.14,<3.15"
+requires-python = "==3.14.6"
 
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = "==3.14.*"
+requires-python = "==3.14.6"
 
 [[package]]
 name = "aws-lambda-context"
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "aws-lambda-telescope-msk"
-version = "0.1.0"
+version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aws-lambda-powertools" },
@@ -42,7 +42,6 @@ dev = [
     { name = "black" },
     { name = "boto3" },
     { name = "colorama" },
-    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-ruff" },
@@ -64,11 +63,10 @@ dev = [
     { name = "black" },
     { name = "boto3" },
     { name = "colorama" },
-    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-ruff" },
-    { name = "version-incrementor", specifier = ">=1.10.0,<2" },
+    { name = "version-incrementor" },
 ]
 
 [[package]]
@@ -178,15 +176,6 @@ wheels = [
     { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/eb/d2/3b7176cb570a1d3e27faf67b72f591af508036e0d8b2be2ef9af9e8c84bb/cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4", size = 182868, upload-time = "2026-08-03T21:20:40.388Z" },
     { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/56/78/31f00c1bcd97c9bbf55f1bfdf5bc809a5de8887473e90bb9960dca825e80/cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e", size = 194104, upload-time = "2026-08-03T21:20:41.725Z" },
     { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/7b/1b/58496f2ed0a35de575250c02a43ab3cc2c04d494a88fed31c1cabc0fd176/cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5", size = 186402, upload-time = "2026-08-03T21:20:43.042Z" },
-]
-
-[[package]]
-name = "cfgv"
-version = "3.5.0"
-source = { registry = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple" }
-sdist = { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
-wheels = [
-    { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
 ]
 
 [[package]]
@@ -348,24 +337,6 @@ wheels = [
 ]
 
 [[package]]
-name = "distlib"
-version = "0.4.3"
-source = { registry = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple" }
-sdist = { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
-wheels = [
-    { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
-]
-
-[[package]]
-name = "filelock"
-version = "3.32.2"
-source = { registry = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple" }
-sdist = { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/f6/57/3ba6e6cb097f85b855b00163d169f35365f44277df044dcf96d55b8f62a3/filelock-3.32.2.tar.gz", hash = "sha256:c33351e1f49cae33414acbc6d56784e6ecee82514ec90795da1161fc4836b5b8", size = 217172, upload-time = "2026-07-29T22:46:04.895Z" }
-wheels = [
-    { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/c1/e8/72f8cef9fdfeffe06213fe8508039396ee48daa0e3259457ed766173bfd6/filelock-3.32.2-py3-none-any.whl", hash = "sha256:87dd94cf281e586d135fa51132b8e3d9a598b316e90377a288663c9321036c82", size = 98830, upload-time = "2026-07-29T22:46:03.52Z" },
-]
-
-[[package]]
 name = "gitdb"
 version = "4.0.12"
 source = { registry = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple" }
@@ -399,15 +370,6 @@ dependencies = [
 sdist = { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/ef/8d/50658d134d89e080bb33eb8e2f75d17563b5a9dfb75383ea1a78e1df6fff/GitPython-3.1.30.tar.gz", hash = "sha256:769c2d83e13f5d938b7688479da374c4e3d49f71549aaf462b646db9602ea6f8", size = 195508, upload-time = "2022-12-29T07:16:38.435Z" }
 wheels = [
     { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/d0/7c/e6942be5f2c03a9de68a6c782373dcec7dc1d10664dd20652bfb7307f905/GitPython-3.1.30-py3-none-any.whl", hash = "sha256:cd455b0000615c60e286208ba540271af9fe531fa6a87cc590a7298785ab2882", size = 184008, upload-time = "2022-12-29T07:16:36.34Z" },
-]
-
-[[package]]
-name = "identify"
-version = "2.6.19"
-source = { registry = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple" }
-sdist = { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
-wheels = [
-    { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -468,15 +430,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.10.0"
-source = { registry = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple" }
-sdist = { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
-wheels = [
-    { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.3"
 source = { registry = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple" }
@@ -510,22 +463,6 @@ source = { registry = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi
 sdist = { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "pre-commit"
-version = "4.6.1"
-source = { registry = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple" }
-dependencies = [
-    { name = "cfgv" },
-    { name = "identify" },
-    { name = "nodeenv" },
-    { name = "pyyaml" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/25/3a/ddb78f32a0814e66b18a099377a106a2dcdce92d86a034d69d65df9b256e/pre_commit-4.6.1.tar.gz", hash = "sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421", size = 198646, upload-time = "2026-07-21T20:56:58.225Z" }
-wheels = [
-    { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl", hash = "sha256:0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717", size = 226186, upload-time = "2026-07-21T20:56:57.064Z" },
 ]
 
 [[package]]
@@ -599,18 +536,6 @@ dependencies = [
 sdist = { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "python-discovery"
-version = "1.5.1"
-source = { registry = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple" }
-dependencies = [
-    { name = "filelock" },
-]
-sdist = { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/04/b7/1581a8103855c43567776aa34135e5ec3c597346c23bfd10c7eb5e0b10a4/python_discovery-1.5.1.tar.gz", hash = "sha256:e2ea8b884cd1701f386eda8cf327b87743f1dc21b7f784470799537d95635384", size = 77200, upload-time = "2026-07-31T22:06:02.48Z" }
-wheels = [
-    { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/6a/07/a89b539750a159d5101c4eb9fc84e2961f65cefbd5e0b7440b284471c0b0/python_discovery-1.5.1-py3-none-any.whl", hash = "sha256:ac07f44cade589d954e9d6a1e1468539fdddd2cf676beb51da73e0f156b7c932", size = 35752, upload-time = "2026-07-31T22:06:01.116Z" },
 ]
 
 [[package]]
@@ -792,19 +717,4 @@ dependencies = [
 sdist = { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/version-incrementor/1.10.0/version-incrementor-1.10.0.tar.gz", hash = "sha256:5026d4573a63352b8d46fe329511a086db8ca5b324ed26de03a0d1a665ff00a7", size = 8084, upload-time = "2023-06-26T15:24:02.995Z" }
 wheels = [
     { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/version-incrementor/1.10.0/version_incrementor-1.10.0-py3-none-any.whl", hash = "sha256:163d68f1734f11e00a262c2e1b0b9bd8c58f5ec6e06bf11150679120ee8663bf", size = 6264, upload-time = "2023-06-26T15:24:02.955Z" },
-]
-
-[[package]]
-name = "virtualenv"
-version = "21.7.1"
-source = { registry = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple" }
-dependencies = [
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "platformdirs" },
-    { name = "python-discovery" },
-]
-sdist = { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/ea/fa/18004e5cb15541ad2a68ff219c755233b012b12d4ec8663d06a258082bec/virtualenv-21.7.1.tar.gz", hash = "sha256:d0dbfaa5483487baea28d7210ef8d24c9d1bd0f10f449eeb215568825a9b334e", size = 5525237, upload-time = "2026-07-30T15:40:36.36Z" }
-wheels = [
-    { url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/packages/packages/4b/a7/ded126c19495158a05c7202b3389139839d4cf78d622d453867778e0f7a8/virtualenv-21.7.1-py3-none-any.whl", hash = "sha256:6394973f990536e34c05157179146c020284c42fe01da1dfeb0ba16c345280d9", size = 5504576, upload-time = "2026-07-30T15:40:34.512Z" },
 ]


### PR DESCRIPTION
What did we do?
--

1. set `requires-python` for `uv` to explicitly match mise's python version

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-5695

Collaboration
--

Co-authored-by: @duddingl
